### PR TITLE
feat: scaffold provider/addon/csi subdirectories (ADR 0008 §1, yage#134)

### DIFF
--- a/addons/argocd-apps/README.md
+++ b/addons/argocd-apps/README.md
@@ -1,0 +1,1 @@
+# argocd-apps — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/argocd/README.md
+++ b/addons/argocd/README.md
@@ -1,0 +1,1 @@
+# argocd — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/cert-manager/README.md
+++ b/addons/cert-manager/README.md
@@ -1,0 +1,1 @@
+# cert-manager — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/cilium/README.md
+++ b/addons/cilium/README.md
@@ -1,0 +1,1 @@
+# cilium — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/cloudnativepg/README.md
+++ b/addons/cloudnativepg/README.md
@@ -1,0 +1,1 @@
+# cloudnativepg — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/crossplane/README.md
+++ b/addons/crossplane/README.md
@@ -1,0 +1,1 @@
+# crossplane — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/external-secrets/README.md
+++ b/addons/external-secrets/README.md
@@ -1,0 +1,1 @@
+# external-secrets — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/infisical/README.md
+++ b/addons/infisical/README.md
@@ -1,0 +1,1 @@
+# infisical — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/keycloak/README.md
+++ b/addons/keycloak/README.md
@@ -1,0 +1,1 @@
+# keycloak — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/kyverno/README.md
+++ b/addons/kyverno/README.md
@@ -1,0 +1,1 @@
+# kyverno — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/metrics-server/README.md
+++ b/addons/metrics-server/README.md
@@ -1,0 +1,1 @@
+# metrics-server — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/observability/README.md
+++ b/addons/observability/README.md
@@ -1,0 +1,1 @@
+# observability — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/opentelemetry/README.md
+++ b/addons/opentelemetry/README.md
@@ -1,0 +1,1 @@
+# opentelemetry — templates pending migration (see lpasquali/yage issue #133)

--- a/addons/spire/README.md
+++ b/addons/spire/README.md
@@ -1,0 +1,1 @@
+# spire — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/aws/README.md
+++ b/cluster/aws/README.md
@@ -1,0 +1,1 @@
+# aws — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/azure/README.md
+++ b/cluster/azure/README.md
@@ -1,0 +1,1 @@
+# azure — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/capd/README.md
+++ b/cluster/capd/README.md
@@ -1,0 +1,1 @@
+# capd — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/digitalocean/README.md
+++ b/cluster/digitalocean/README.md
@@ -1,0 +1,1 @@
+# digitalocean — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/gcp/README.md
+++ b/cluster/gcp/README.md
@@ -1,0 +1,1 @@
+# gcp — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/hetzner/README.md
+++ b/cluster/hetzner/README.md
@@ -1,0 +1,1 @@
+# hetzner — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/ibmcloud/README.md
+++ b/cluster/ibmcloud/README.md
@@ -1,0 +1,1 @@
+# ibmcloud — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/linode/README.md
+++ b/cluster/linode/README.md
@@ -1,0 +1,1 @@
+# linode — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/oci/README.md
+++ b/cluster/oci/README.md
@@ -1,0 +1,1 @@
+# oci — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/openstack/README.md
+++ b/cluster/openstack/README.md
@@ -1,0 +1,1 @@
+# openstack — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/proxmox/README.md
+++ b/cluster/proxmox/README.md
@@ -1,0 +1,1 @@
+# proxmox — templates pending migration (see lpasquali/yage issue #133)

--- a/cluster/vsphere/README.md
+++ b/cluster/vsphere/README.md
@@ -1,0 +1,1 @@
+# vsphere — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/aws-ebs/README.md
+++ b/csi/aws-ebs/README.md
@@ -1,0 +1,1 @@
+# aws-ebs — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/azure-disk/README.md
+++ b/csi/azure-disk/README.md
@@ -1,0 +1,1 @@
+# azure-disk — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/do-block-storage/README.md
+++ b/csi/do-block-storage/README.md
@@ -1,0 +1,1 @@
+# do-block-storage — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/gcp-pd/README.md
+++ b/csi/gcp-pd/README.md
@@ -1,0 +1,1 @@
+# gcp-pd — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/hcloud/README.md
+++ b/csi/hcloud/README.md
@@ -1,0 +1,1 @@
+# hcloud — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/ibm-vpc-block/README.md
+++ b/csi/ibm-vpc-block/README.md
@@ -1,0 +1,1 @@
+# ibm-vpc-block — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/linode-block-storage/README.md
+++ b/csi/linode-block-storage/README.md
@@ -1,0 +1,1 @@
+# linode-block-storage — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/longhorn/README.md
+++ b/csi/longhorn/README.md
@@ -1,0 +1,1 @@
+# longhorn — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/oci-block-storage/README.md
+++ b/csi/oci-block-storage/README.md
@@ -1,0 +1,1 @@
+# oci-block-storage — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/openebs/README.md
+++ b/csi/openebs/README.md
@@ -1,0 +1,1 @@
+# openebs — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/openstack-cinder/README.md
+++ b/csi/openstack-cinder/README.md
@@ -1,0 +1,1 @@
+# openstack-cinder — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/proxmox-csi/README.md
+++ b/csi/proxmox-csi/README.md
@@ -1,0 +1,1 @@
+# proxmox-csi — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/rook-ceph/README.md
+++ b/csi/rook-ceph/README.md
@@ -1,0 +1,1 @@
+# rook-ceph — templates pending migration (see lpasquali/yage issue #133)

--- a/csi/vsphere-csi/README.md
+++ b/csi/vsphere-csi/README.md
@@ -1,0 +1,1 @@
+# vsphere-csi — templates pending migration (see lpasquali/yage issue #133)


### PR DESCRIPTION
## Summary

- Add stub `README.md` files for all 12 cluster provider directories, 14 add-on directories, and 14 CSI driver directories
- Each stub contains one line: `# <name> — templates pending migration (see lpasquali/yage issue #133)`
- No template files (`.yaml.tmpl`) — those follow in issues #137–#141

## Directory naming notes

- **CSI directories** use the full hyphenated names from the existing `csi/README.md` (e.g., `proxmox-csi/`, `linode-block-storage/`, `do-block-storage/`, `oci-block-storage/`) rather than the shorter aliases in the issue text. These match yage's driver registry lookups and will be the lookup key when templates are migrated.
- **Addons directories** include 14 entries (adds `argocd-apps`, `cloudnativepg`, `infisical`, `opentelemetry`, `keycloak` beyond the 9 in the issue text) to match the full set in `addons/README.md`.

## Closes

Closes yage#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)