### PR TITLE
feat(caaph): add HelmChartProxy and ArgoCD CR templates (yage#140)

### DIFF
--- a/addons/argocd-apps/helmchartproxy.yaml.tmpl
+++ b/addons/argocd-apps/helmchartproxy.yaml.tmpl
@@ -1,0 +1,21 @@
+# yage-manifests/addons/argocd-apps/helmchartproxy.yaml.tmpl
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  clusterSelector:
+    matchLabels:
+      caaph: enabled
+  chartName: {{ .ChartName }}
+  repoURL: {{ .RepoURL }}
+  namespace: {{ .ChartNamespace }}
+  options:
+    wait: true
+    waitForJobs: true
+    timeout: 20m0s
+    install:
+      createNamespace: true
+  valuesTemplate: |
+{{ .ValuesTemplate }}

--- a/addons/argocd/argocd-cr.yaml.tmpl
+++ b/addons/argocd/argocd-cr.yaml.tmpl
@@ -1,0 +1,38 @@
+# yage-manifests/addons/argocd/argocd-cr.yaml.tmpl
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+spec:
+  version: {{ .Cfg.ArgoCD.Version }}
+  prometheus:
+    enabled: {{ index .Bools "promEnabled" }}
+  monitoring:
+    enabled: {{ index .Bools "monEnabled" }}
+  notifications:
+    enabled: true
+  server:
+{{- if and (index .Bools "disableIngress") (index .Bools "serverInsecure") }}
+    insecure: true
+    ingress:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+{{- else if index .Bools "disableIngress" }}
+    ingress:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+{{- else if index .Bools "serverInsecure" }}
+    insecure: true
+    grpc:
+      ingress:
+        enabled: true
+{{- else }}
+    grpc:
+      ingress:
+        enabled: true
+{{- end }}

--- a/addons/cilium/helmchartproxy.yaml.tmpl
+++ b/addons/cilium/helmchartproxy.yaml.tmpl
@@ -1,0 +1,22 @@
+# yage-manifests/addons/cilium/helmchartproxy.yaml.tmpl
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  clusterSelector:
+    matchLabels:
+      caaph: enabled
+  chartName: {{ .ChartName }}
+  repoURL: {{ .RepoURL }}
+  version: {{ printf "%q" .Version }}
+  namespace: {{ .ChartNamespace }}
+  options:
+    wait: true
+    waitForJobs: true
+    timeout: 15m0s
+    install:
+      createNamespace: true
+  valuesTemplate: |
+{{ .ValuesTemplate }}


### PR DESCRIPTION
## Summary

- Adds `addons/cilium/helmchartproxy.yaml.tmpl` — Cilium CAAPH HelmChartProxy template using `HelmChartProxyData` wrapper struct
- Adds `addons/argocd-apps/helmchartproxy.yaml.tmpl` — argocd-apps CAAPH HelmChartProxy template using `HelmChartProxyData` wrapper struct
- Adds `addons/argocd/argocd-cr.yaml.tmpl` — ArgoCD operator CR template using `HelmValuesData` + `Bools map[string]bool` for conditional server block

Both HCP templates receive a pre-built `ValuesTemplate` string from the Go caller; CAAPH inner `{{ }}` delimiters pass through as literal text and are never interpreted by `text/template` — ADR 0008 §2 escaping is not needed with this pattern.

The ArgoCD CR template uses `{{- if }}` / `{{- else }}` / `{{- end }}` whitespace trimming to preserve exact byte-for-byte YAML output matching the original `buildArgoCDCR` Go renderer.

## ADR compliance

- ADR 0008 §2: inner-delimiter escaping not needed (ValuesTemplate pattern)
- ADR 0012 §2: `helmchartproxy.yaml.tmpl` file naming; `argocd-cr.yaml.tmpl` under `addons/argocd/`
- ADR 0012 §3: wrapper struct contracts honored; `HelmValuesData.Bools` extension permitted per migration-PR policy
- ADR 0012 §4: `missingkey=error` enforced by Fetcher
- ADR 0012 §5: one logical resource per file; no leading `---`

## Test plan

- [ ] Templates render correctly with yage golden tests in `internal/capi/caaph/caaph_test.go` (7 tests, all pass)
- [ ] `go test ./...` in yage repo: all tests pass
- [ ] `go build ./...` clean; `go vet ./...` clean

Closes via yage PR feat(caaph): migrate to yage-manifests templates (#140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)