### PR TITLE
feat(addons): migrate helmvalues to templates + converge caaph to isTrue (yage#137, ADR 0012 E1)

### DIFF
--- a/addons/argocd/argocd-cr.yaml.tmpl
+++ b/addons/argocd/argocd-cr.yaml.tmpl
@@ -7,26 +7,26 @@ metadata:
 spec:
   version: {{ .Cfg.ArgoCD.Version }}
   prometheus:
-    enabled: {{ index .Bools "promEnabled" }}
+    enabled: {{ isTrue .Cfg.ArgoCD.PrometheusEnabled }}
   monitoring:
-    enabled: {{ index .Bools "monEnabled" }}
+    enabled: {{ isTrue .Cfg.ArgoCD.MonitoringEnabled }}
   notifications:
     enabled: true
   server:
-{{- if and (index .Bools "disableIngress") (index .Bools "serverInsecure") }}
+{{- if and (isTrue .Cfg.ArgoCD.DisableOperatorManagedIngress) (isTrue .Cfg.ArgoCD.ServerInsecure) }}
     insecure: true
     ingress:
       enabled: false
     grpc:
       ingress:
         enabled: false
-{{- else if index .Bools "disableIngress" }}
+{{- else if isTrue .Cfg.ArgoCD.DisableOperatorManagedIngress }}
     ingress:
       enabled: false
     grpc:
       ingress:
         enabled: false
-{{- else if index .Bools "serverInsecure" }}
+{{- else if isTrue .Cfg.ArgoCD.ServerInsecure }}
     insecure: true
     grpc:
       ingress:

--- a/addons/keycloak/values.yaml.tmpl
+++ b/addons/keycloak/values.yaml.tmpl
@@ -1,0 +1,31 @@
+# yage-manifests/addons/keycloak/values.yaml.tmpl
+{{- if .Cfg.KeycloakEnabled }}
+args:
+  - start
+extraEnv: |
+  - name: KC_HOSTNAME_STRICT
+    value: "{{ .Cfg.KeycloakKcHostnameStrict }}"
+  - name: KC_HOSTNAME
+    value: "{{ .Cfg.KeycloakKcHostname }}"
+{{- if .Cfg.KeycloakKcDB }}
+  - name: KC_DB
+    value: "{{ .Cfg.KeycloakKcDB }}"
+{{- end }}
+{{- if .Cfg.SPIREEnabled }}
+{{- $oidc := printf "%s-spire-spiffe-oidc-discovery-provider.%s.svc.cluster.local" .Cfg.WorkloadClusterName .Cfg.SPIRENamespace }}
+{{- if isTrue .Cfg.SPIREOIDCInsecureHTTP }}
+  - name: SPIFFE_OIDC_WELL_KNOWN_URL
+    value: "http://{{ $oidc }}/.well-known/openid-configuration"
+  - name: SPIFFE_OIDC_ISSUER_HOST
+    value: "{{ $oidc }}"
+  - name: KEYCLOAK_SPIRE_IDP_HELP
+    value: "Add an Identity Provider (OpenID v1) in Keycloak using SPIFFE_OIDC_WELL_KNOWN_URL; map SPIFFE SVIDs to users as needed."
+{{- else }}
+  - name: SPIFFE_OIDC_WELL_KNOWN_URL
+    value: "https://{{ $oidc }}/.well-known/openid-configuration"
+  - name: SPIFFE_OIDC_ISSUER_HOST
+    value: "{{ $oidc }}"
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/addons/metrics-server/values.yaml.tmpl
+++ b/addons/metrics-server/values.yaml.tmpl
@@ -1,0 +1,10 @@
+# yage-manifests/addons/metrics-server/values.yaml.tmpl
+{{- if isTrue .Cfg.WorkloadMetricsServerInsecureTLS }}
+defaultArgs:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
+args:
+  - --kubelet-insecure-tls
+{{- end }}

--- a/addons/observability/values-grafana.yaml.tmpl
+++ b/addons/observability/values-grafana.yaml.tmpl
@@ -1,0 +1,44 @@
+# yage-manifests/addons/observability/values-grafana.yaml.tmpl
+service:
+  type: ClusterIP
+{{- if .Cfg.VictoriaMetricsEnabled }}
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: VictoriaMetrics
+        type: prometheus
+        url: http://vmsingle.{{ .Cfg.VictoriaMetricsNamespace }}.svc:8428
+        access: proxy
+        isDefault: true
+        jsonData:
+          httpMethod: POST
+          manageAlerts: true
+          prometheusType: Prometheus
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/default
+dashboards:
+  default:
+    k8s-cluster:
+      gnetId: 7249
+      revision: 1
+      datasource: VictoriaMetrics
+    k8s-api-server:
+      gnetId: 12006
+      revision: 1
+      datasource: VictoriaMetrics
+    victoriametrics-single:
+      gnetId: 10229
+      revision: 1
+      datasource: VictoriaMetrics
+{{- end }}

--- a/addons/observability/values-victoria-metrics.yaml.tmpl
+++ b/addons/observability/values-victoria-metrics.yaml.tmpl
@@ -1,0 +1,19 @@
+# yage-manifests/addons/observability/values-victoria-metrics.yaml.tmpl
+server:
+  fullnameOverride: vmsingle
+  scrape:
+    enabled: true
+    extraScrapeConfigs:
+      - job_name: kubernetes-endpoints-metrics-ports
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - action: keep
+            source_labels: [__meta_kubernetes_endpoint_port_name]
+            regex: metrics|http-metrics
+          - action: replace
+            source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - action: replace
+            source_labels: [__meta_kubernetes_service_name]
+            target_label: service

--- a/addons/opentelemetry/values.yaml.tmpl
+++ b/addons/opentelemetry/values.yaml.tmpl
@@ -1,0 +1,4 @@
+# yage-manifests/addons/opentelemetry/values.yaml.tmpl
+mode: {{ .Cfg.OTELCollectorMode }}
+image:
+  repository: {{ .Cfg.OTELImageRepository }}

--- a/addons/spire/values.yaml.tmpl
+++ b/addons/spire/values.yaml.tmpl
@@ -1,0 +1,67 @@
+# yage-manifests/addons/spire/values.yaml.tmpl
+global:
+  spire:
+    clusterName: {{ .Cfg.WorkloadClusterName }}
+    trustDomain: k8s.{{ .Cfg.WorkloadClusterName }}.local
+{{- if not (isTrue .Cfg.SPIREHelmEnableGlobalHooks) }}
+  installAndUpgradeHooks:
+    enabled: false
+  deleteHooks:
+    enabled: false
+{{- end }}
+{{- if isTrue .Cfg.SPIRETolerateControlPlane }}
+spire-server:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spire-controller-manager:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spire-agent:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spiffe-csi-driver:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+{{- end }}
+spiffe-oidc-discovery-provider:
+{{- if isTrue .Cfg.SPIRETolerateControlPlane }}
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+{{- end }}
+  bundleSource: {{ .Cfg.SPIREOIDCBundleSource }}
+  config:
+{{- if .Cfg.KeycloakEnabled }}
+    setKeyUse: true
+{{- else }}
+    setKeyUse: false
+{{- end }}
+{{- if and .Cfg.KeycloakEnabled (isTrue .Cfg.SPIREOIDCInsecureHTTP) }}
+  tls:
+    spire:
+      enabled: false
+{{- end }}


### PR DESCRIPTION
## Summary

- **caaph convergence**: replaces `{{ index .Bools "..." }}` in `addons/argocd/argocd-cr.yaml.tmpl` with `{{ isTrue .Cfg.ArgoCD.X }}` per ADR 0012 §4.1 Errata E1; removes the `Bools` extension that PR #4 introduced.
- **helmvalues migration (#137)**: adds six `values.yaml.tmpl` templates for metrics-server, victoria-metrics, grafana, opentelemetry, spire, and keycloak; all string-field branches use `isTrue` FuncMap function.
- **ADR 0012 E1 compliance**: every admitted template function routes through `Fetcher.RegisterFunc`; callers register `sysinfo.IsTrue` as `isTrue` before rendering.

## Files changed

| File | Change |
|---|---|
| `addons/argocd/argocd-cr.yaml.tmpl` | `{{ index .Bools "..." }}` → `{{ isTrue .Cfg.ArgoCD.X }}`; removes Bools dependency |
| `addons/metrics-server/values.yaml.tmpl` | new — mirrors `helmvalues.MetricsServerValues` |
| `addons/observability/values-victoria-metrics.yaml.tmpl` | new — mirrors `helmvalues.VictoriaMetricsValues` |
| `addons/observability/values-grafana.yaml.tmpl` | new — mirrors `helmvalues.GrafanaValues` |
| `addons/opentelemetry/values.yaml.tmpl` | new — mirrors `helmvalues.OpenTelemetryValues` |
| `addons/spire/values.yaml.tmpl` | new — mirrors `helmvalues.SPIREValues` (inlines SPIRESubchartTolerations) |
| `addons/keycloak/values.yaml.tmpl` | new — mirrors `helmvalues.KeycloakValues` |

## Acceptance Criteria Evidence

- All templates validated by golden tests in the companion yage PR (13 helmvalues tests + 7 caaph tests pass byte-for-byte).
- `{{ isTrue }}` function used exclusively for string→bool coercion; no `{{ index .Bools }}` pattern remains.

## Audit Checks

No triggers fired.

## Breaking Changes

None. Callers must register `isTrue` via `Fetcher.RegisterFunc("isTrue", sysinfo.IsTrue)` before rendering any template that uses the function. The companion yage PR adds `helmvalues.RegisterIsTrue(f)` at the bootstrap Fetcher construction site.