### PR TITLE
docs(readme): mark v0.1.0 as empty/deprecated; operators must use >=v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ go run github.com/lpasquali/yage/tools/render-template \
 
 ## Versioning
 
-Tagged with semver (`v0.1.0`, `v0.2.0`, …). Breaking template changes bump the minor version until v1.0.0. yage pins via `YAGE_MANIFESTS_REF`.
+Tagged with semver (`v0.2.0`, `v0.3.0`, …). Breaking template changes bump the minor version until v1.0.0. yage pins via `YAGE_MANIFESTS_REF`.
+
+**`v0.1.0` is empty and deprecated.** It tagged the initial scaffold commit (`c0a693e`) which contained only directory structure and READMEs — no `.yaml.tmpl` files. Any deployment using `YAGE_MANIFESTS_REF=v0.1.0` will fail at template render time. Use `>=v0.2.0`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Flags `v0.1.0` as deprecated in the README. That tag pointed at the empty scaffold commit (`c0a693e`) with no `.yaml.tmpl` files; any deployment using `YAGE_MANIFESTS_REF=v0.1.0` fails at template render time.
- `v0.2.0` is now live (tag `4607ee1`, commit `ca00059`) and is the first usable release containing caaph and helmvalues templates.
- Updates the Versioning section example to start from `v0.2.0`.

## Definition of Done

- [x] **Level 3 — Documentation Only**: no Go code changed; README updated only.

## Acceptance Criteria Evidence

- `v0.2.0` tag is live: `gh api repos/lpasquali/yage-manifests/git/refs/tags/v0.2.0` resolves to tag object `4607ee1` → commit `ca00059`.
- README now contains explicit warning that `v0.1.0` is empty and deprecated.

## Audit Checks

No triggers fired.

## Breaking Changes

None (documentation only).