### PR TITLE
feat(postsync): add _partials kustomize templates for job-image-override and proxmox-csi-smoke (yage#139)

### DIFF
--- a/postsync/_partials/job-image-override.kustomize.tmpl
+++ b/postsync/_partials/job-image-override.kustomize.tmpl
@@ -1,0 +1,13 @@
+# yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'

--- a/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+++ b/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
@@ -1,0 +1,19 @@
+# yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'
+            - op: replace
+              path: /spec/template/spec/containers/0/env/0/value
+              value: "{{ .Namespace }}"
+            - op: replace
+              path: /spec/template/spec/containers/0/env/1/value
+              value: "{{ index .Extra "storageClass" }}"


### PR DESCRIPTION
## Summary

- Adds `postsync/_partials/job-image-override.kustomize.tmpl` parameterized by `KustomizePartialData{Namespace, JobName, KubectlImage}` — covers all job-name callers across add-ons (metrics-server-smoketest, proxmox-csi-rollout-smoketest, kyverno-smoketest, etc.)
- Adds `postsync/_partials/proxmox-csi-smoke.kustomize.tmpl` parameterized by `KustomizePartialData{Namespace, JobName, KubectlImage, Extra["storageClass"]}` — emits image override + env/0 (namespace) + env/1 (storageClass) patches for the Proxmox CSI smoke Job

**Migration table (ADR 0012 §3 — postsync subset):**

| Go function | Template | Wrapper struct |
|---|---|---|
| `KustomizeBlockForJob` | `postsync/_partials/job-image-override.kustomize.tmpl` | `KustomizePartialData` |
| `SmokeRenderKustomizeBlock` | `postsync/_partials/proxmox-csi-smoke.kustomize.tmpl` | `KustomizePartialData` |

Both files follow ADR 0012 §2 conventions: leading `# yage-manifests/<path>` provenance header, `_partials/` subdirectory marking them as fragments (not standalone manifests), `.kustomize.tmpl` extension per the partial naming rule.

## **Definition of Done**

- **Two template files only** — no other files changed
- **Both use `KustomizePartialData`** — no struct extension required
- **No `postsync/<hookname>.yaml.tmpl` files** — no `PostSyncData` consumer exists

## Acceptance Criteria Evidence

- Templates render correctly via `KustomizeBlockForJobTemplate` and `SmokeRenderKustomizeBlockTemplate` in yage PR (companion PR to this one)
- 8 golden tests pass: `TestKustomizeBlockForJobTemplate_*` (5 cases) + `TestSmokeRenderKustomizeBlockTemplate_*` (3 cases)
- Testdata fixtures in `yage/internal/capi/postsync/testdata/` are byte-for-byte identical to these templates (verified via `diff`)

## Audit Checks

No triggers fired.

## Breaking Changes

None. These are new template files; no existing template paths are modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)