### PR TITLE
feat(addons): wlargocd application.yaml.tmpl for 14 add-ons (lpasquali/yage#138)

### DIFF
--- a/addons/backstage/README.md
+++ b/addons/backstage/README.md
@@ -1,0 +1,3 @@
+# backstage
+
+Workload Argo CD Application template for the backstage add-on (lpasquali/yage issue #138).

--- a/addons/backstage/application.yaml.tmpl
+++ b/addons/backstage/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/backstage/application.yaml.tmpl
+Helm-repo Argo CD Application for backstage.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/cert-manager/application.yaml.tmpl
+++ b/addons/cert-manager/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/cert-manager/application.yaml.tmpl
+Helm-repo Argo CD Application for cert-manager.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/cloudnativepg/application.yaml.tmpl
+++ b/addons/cloudnativepg/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/cloudnativepg/application.yaml.tmpl
+Helm-repo Argo CD Application for cloudnativepg.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/crossplane/application.yaml.tmpl
+++ b/addons/crossplane/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/crossplane/application.yaml.tmpl
+Helm-repo Argo CD Application for crossplane.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/external-secrets/application.yaml.tmpl
+++ b/addons/external-secrets/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/external-secrets/application.yaml.tmpl
+Helm-repo Argo CD Application for external-secrets.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/infisical/application.yaml.tmpl
+++ b/addons/infisical/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/infisical/application.yaml.tmpl
+Helm-repo Argo CD Application for infisical.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/keycloak-realm-operator/README.md
+++ b/addons/keycloak-realm-operator/README.md
@@ -1,0 +1,3 @@
+# keycloak-realm-operator
+
+Workload Argo CD Application template for the keycloak-realm-operator add-on (lpasquali/yage issue #138).

--- a/addons/keycloak-realm-operator/application.yaml.tmpl
+++ b/addons/keycloak-realm-operator/application.yaml.tmpl
@@ -1,0 +1,44 @@
+{{- /*
+yage-manifests/addons/keycloak-realm-operator/application.yaml.tmpl
+KustomizeGit-shape Argo CD Application: kustomize tree from a Git source.
+.ValuesYAML carries the pre-indented kustomize block (depth 4 single,
+depth 6 multi-source — Go-side picks the correct depth).
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: '{{ .Ref }}'
+{{ .ValuesYAML -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: '{{ .Ref }}'
+{{ .ValuesYAML -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/keycloak/application.yaml.tmpl
+++ b/addons/keycloak/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/keycloak/application.yaml.tmpl
+Helm-repo Argo CD Application for keycloak.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/kyverno/application.yaml.tmpl
+++ b/addons/kyverno/application.yaml.tmpl
@@ -1,0 +1,103 @@
+{{- /*
+yage-manifests/addons/kyverno/application.yaml.tmpl
+Kyverno Argo CD Application — a Helm-shape source plus Kyverno-specific
+extras: the `compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`
+annotation, the structured valuesObject (config + tolerations +
+4 controller replicas), and the ignoreDifferences for caBundle drift.
+The KyvernoTolerateControlPlane string is read via the isTrue FuncMap;
+the caller (orchestrator) registers isTrue on the Fetcher.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+          config:
+            preserve: false
+            webhookLabels:
+              app.kubernetes.io/managed-by: argocd
+{{- if isTrue .Cfg.KyvernoTolerateControlPlane }}
+          global:
+            tolerations:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+                effect: NoSchedule
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+                effect: NoSchedule
+{{- end }}
+          admissionController:
+            replicas: 1
+          backgroundController:
+            replicas: 1
+          cleanupController:
+            replicas: 1
+          reportsController:
+            replicas: 1
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+        config:
+          preserve: false
+          webhookLabels:
+            app.kubernetes.io/managed-by: argocd
+{{- if isTrue .Cfg.KyvernoTolerateControlPlane }}
+        global:
+          tolerations:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: Exists
+              effect: NoSchedule
+            - key: "node-role.kubernetes.io/master"
+              operator: Exists
+              effect: NoSchedule
+{{- end }}
+        admissionController:
+          replicas: 1
+        backgroundController:
+          replicas: 1
+        cleanupController:
+          replicas: 1
+        reportsController:
+          replicas: 1
+{{- end }}
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/metrics-server/application.yaml.tmpl
+++ b/addons/metrics-server/application.yaml.tmpl
@@ -1,0 +1,62 @@
+{{- /*
+yage-manifests/addons/metrics-server/application.yaml.tmpl
+HelmGit-shape Argo CD Application: chart pulled from a Git source.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+Ref is shell-quote-escaped Go-side and emitted single-quoted.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: '{{ .Ref }}'
+      helm:
+{{- if .ReleaseName }}
+        releaseName: {{ .ReleaseName }}
+{{- end }}
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: '{{ .Ref }}'
+    helm:
+{{- if .ReleaseName }}
+      releaseName: {{ .ReleaseName }}
+{{- end }}
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/observability/application.yaml.tmpl
+++ b/addons/observability/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/observability/application.yaml.tmpl
+Helm-repo Argo CD Application for observability.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/opentelemetry/application.yaml.tmpl
+++ b/addons/opentelemetry/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/opentelemetry/application.yaml.tmpl
+Helm-repo Argo CD Application for opentelemetry.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/proxmox-csi/README.md
+++ b/addons/proxmox-csi/README.md
@@ -1,0 +1,3 @@
+# proxmox-csi
+
+Workload Argo CD Application template for the proxmox-csi add-on (lpasquali/yage issue #138).

--- a/addons/proxmox-csi/application.yaml.tmpl
+++ b/addons/proxmox-csi/application.yaml.tmpl
@@ -1,0 +1,57 @@
+{{- /*
+yage-manifests/addons/proxmox-csi/application.yaml.tmpl
+HelmOCI-shape Argo CD Application: chart from an OCI Helm registry.
+PostSyncs slice carries 0, 1, or 2 hooks (the proxmox-csi smoke variant
+uses 2 hooks together: pvc + rollout). The chart is encoded in the OCI
+URL; the template emits `path: "."`.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/addons/spire/application.yaml.tmpl
+++ b/addons/spire/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/spire/application.yaml.tmpl
+Helm-repo Argo CD Application for spire.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Companion PR to lpasquali/yage#138 (wlargocd → yage-manifests templates).
Adds `application.yaml.tmpl` files under `addons/<addon>/` for the 14
in-cluster Argo CD Applications the orchestrator renders via
`internal/capi/wlargocd`.

## Templates added (14)

| Addon dir | Shape | Renderer |
|---|---|---|
| `addons/metrics-server/` | HelmGit (chart from git) | `wlargocd.HelmGit` |
| `addons/cert-manager/` | Helm (HTTP repo) | `wlargocd.Helm` |
| `addons/crossplane/` | Helm | `wlargocd.Helm` |
| `addons/cloudnativepg/` | Helm | `wlargocd.Helm` (cnpg) |
| `addons/external-secrets/` | Helm | `wlargocd.Helm` |
| `addons/infisical/` | Helm | `wlargocd.Helm` |
| `addons/observability/` | Helm | `wlargocd.Helm` (vm + grafana share dir) |
| `addons/opentelemetry/` | Helm | `wlargocd.Helm` |
| `addons/backstage/` | Helm | `wlargocd.Helm` |
| `addons/keycloak/` | Helm | `wlargocd.Helm` |
| `addons/spire/` | Helm | `wlargocd.Helm` (spire-crds + spire share dir) |
| `addons/kyverno/` | Kyverno (Helm + extras) | `wlargocd.Kyverno` |
| `addons/proxmox-csi/` | HelmOCI (1 or 2 PostSync hooks) | `wlargocd.HelmOCI` |
| `addons/keycloak-realm-operator/` | KustomizeGit | `wlargocd.KustomizeGit` |

## ADR compliance

- ADR 0008 §1: per-addon directory layout (one `application.yaml.tmpl` per addon dir, intentional duplication for fork-affordance per ADR 0012 Consequences).
- ADR 0012 §3: data contract is `templates.ArgoApplicationData` (extended in lpasquali/yage#138 PR — `PostSync` → `PostSyncs []PostSyncBlock` for the HelmOCI two-hook case).
- ADR 0012 §4: `missingkey=error` enforced by Fetcher; templates only reference declared fields.
- ADR 0012 §4.1: `kyverno/application.yaml.tmpl` uses `isTrue` FuncMap on `KyvernoTolerateControlPlane`. No new FuncMap entries.
- ADR 0008 §2: no inner-delimiter escaping needed (no CAAPH templates).

## Notes

- ADR table gaps confirmed and resolved: `backstage`, `cloudnativepg/` (cnpg), `keycloak-realm-operator/` were not enumerated in ADR 0012 but follow the public-facing per-addon naming rule. Flagged in companion PR.
- `addons/observability/` hosts both VictoriaMetrics and Grafana — both call `wlargocd.Helm` against the same `application.yaml.tmpl`; per-addon values files (`values-victoria-metrics.yaml.tmpl`, `values-grafana.yaml.tmpl`) already exist from PR #5.
- `addons/spire/` is reused for spire-crds (no values) and spire (full values).

Companion: lpasquali/yage#138.