### PR TITLE
ci(quality): ignore multi-line {{- /* ... */ -}} comment headers

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -51,7 +51,20 @@ jobs:
           find . -name '*.yaml.tmpl' -empty | grep . && { echo "::error::empty template files found"; exit 1; } || echo "no empty templates"
       - name: Check for unclosed template actions
         run: |
-          ! grep -rn '{{[^}]*$' --include='*.yaml.tmpl' . || { echo "::error::unclosed template action found"; exit 1; }
+          set -euo pipefail
+          # Catch lines with `{{` that have no closing `}}` on the same line (a
+          # true unclosed action), while ignoring lines that only open a
+          # multi-line Go-template comment block: `{{- /*` or `{{ /*` (these
+          # close on a later line with `*/ -}}` and are valid).
+          matches=$(grep -rnE '\{\{[^}]*$' --include='*.yaml.tmpl' . \
+            | grep -vE ':[0-9]+:[[:space:]]*\{\{-?[[:space:]]*/\*[[:space:]]*$' \
+            || true)
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo "::error::unclosed template action found"
+            exit 1
+          fi
+          echo "no unclosed template actions"
 
   merge-gate:
     name: Merge Gate


### PR DESCRIPTION
## Summary

The `RuneGate/Quality/Templates` step uses `! grep -rn '{{[^}]*$'` to catch a `{{` action with no closing `}}` on the same line. It false-positives on the legitimate multi-line Go-template comment header pattern:

```gotmpl
{{- /*
yage-manifests/addons/<addon>/application.yaml.tmpl
... description ...
*/ -}}
```

All 14 wlargocd addon `application.yaml.tmpl` files added in #10 begin with such a header, so the lint blocks #10 even though every template renders cleanly.

## Change

Relax the unclosed-action check to skip lines whose entire content is `{{- /*` or `{{ /*` (the established multi-line comment-open shape), while still failing on a true unbalanced action.

```bash
matches=$(grep -rnE '\{\{[^}]*$' --include='*.yaml.tmpl' . \
  | grep -vE ':[0-9]+:[[:space:]]*\{\{-?[[:space:]]*/\*[[:space:]]*$' \
  || true)
```

The exclusion is anchored to the *line content* (after `path:N:`), so a contrived line that has both a comment-open and a real unbalanced `{{` would still trip the check. Only line-1-style `{{- /*` headers get skipped.

## Evidence

Run on this repo's tree (relaxed regex, repo as-is):

```
$ grep -rnE '\{\{[^}]*$' --include='*.yaml.tmpl' . \
   | grep -vE ':[0-9]+:[[:space:]]*\{\{-?[[:space:]]*/\*[[:space:]]*$' || true
(empty)
```

Run against a fixture with a real unbalanced action:

```
$ cat /tmp/lint-test/bad.yaml.tmpl
apiVersion: v1
kind: ConfigMap
data:
  foo: {{ .Foo
  bar: baz

$ grep -rnE '\{\{[^}]*$' --include='*.yaml.tmpl' /tmp/lint-test \
   | grep -vE ':[0-9]+:[[:space:]]*\{\{-?[[:space:]]*/\*[[:space:]]*$' || true
/tmp/lint-test/bad.yaml.tmpl:4:  foo: {{ .Foo
```

## Trade-off

The relaxed regex no longer flags an *unclosed comment block* (e.g. `{{- /*` with no matching `*/ -}}`). That mode wasn't the lint's stated purpose (unclosed *action*), and Go template parsing still rejects unclosed comments at render time. Acceptable.

## Follow-up

PR #10 will rebase on `init` after this merges to retrigger CI; v0.4.0 is cut from the resulting `init` HEAD.

Closes #11